### PR TITLE
@gib: version bump; use latest activerecord and rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gris (0.3.2)
+    gris (0.3.3)
       activesupport (~> 4.2, >= 4.2.0)
       chronic (~> 0.10.0)
       dalli (~> 2.7)
@@ -19,14 +19,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.1)
-      activesupport (= 4.2.1)
+    activemodel (4.2.2)
+      activesupport (= 4.2.2)
       builder (~> 3.1)
-    activerecord (4.2.1)
-      activemodel (= 4.2.1)
-      activesupport (= 4.2.1)
+    activerecord (4.2.2)
+      activemodel (= 4.2.2)
+      activesupport (= 4.2.2)
       arel (~> 6.0)
-    activesupport (4.2.1)
+    activesupport (4.2.2)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -112,7 +112,7 @@ GEM
       multi_json (~> 1.10)
     mini_portile (0.6.2)
     minitest (5.7.0)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4)
@@ -121,7 +121,7 @@ GEM
     parser (2.2.2.5)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
-    rack (1.6.1)
+    rack (1.6.2)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-mount (0.8.3)

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 
   class Version
     class << self


### PR DESCRIPTION
Just moves gris to recent patched versions of rack and activerecord per https://gemnasium.com/artsy/gris/alerts