### PR TITLE
@bhoggard: version bump; corrects generated readme and api endpoint specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gris (0.3.4)
+    gris (0.3.5)
       activesupport (~> 4.2, >= 4.2.0)
       chronic (~> 0.10.0)
       dalli (~> 2.7)
@@ -10,6 +10,7 @@ PATH
       grape-roar (~> 0.3.0, >= 0.3.0)
       grape-swagger (~> 0.10.0)
       hashie-forbidden_attributes (~> 0.1.0)
+      indefinite_article (~> 0.2)
       logging (~> 2.0)
       racksh (~> 1.0)
       rake (~> 10.4, >= 10.4.2)
@@ -105,6 +106,8 @@ GEM
       uri_template (~> 0.5)
     i18n (0.7.0)
     ice_nine (0.11.1)
+    indefinite_article (0.2.4)
+      activesupport
     json (1.8.3)
     little-plugger (1.1.3)
     logging (2.0.0)
@@ -112,7 +115,7 @@ GEM
       multi_json (~> 1.10)
     mini_portile (0.6.2)
     minitest (5.7.0)
-    multi_json (1.11.1)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4)
@@ -133,7 +136,7 @@ GEM
       rack-test (>= 0.5)
     rainbow (2.0.0)
     rake (10.4.2)
-    representable (2.2.2)
+    representable (2.2.3)
       multi_json
       nokogiri
       uber (~> 0.0.7)

--- a/gris.gemspec
+++ b/gris.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'hashie-forbidden_attributes', '~> 0.1.0'
   s.add_runtime_dependency 'chronic', '~> 0.10.0'
   s.add_runtime_dependency 'dalli', '~> 2.7'
+  s.add_runtime_dependency 'indefinite_article', '~> 0.2'
 
   s.add_development_dependency 'bundler', '~> 1'
   s.add_development_dependency 'rspec', '~> 3.2'

--- a/lib/gris.rb
+++ b/lib/gris.rb
@@ -9,6 +9,7 @@ require 'roar/representer'
 require 'roar/json'
 require 'roar/json/hal'
 require 'hashie-forbidden_attributes'
+require 'indefinite_article'
 
 # require internal files
 require 'gris/application'

--- a/lib/gris/generators/templates/api/spec/endpoints/%name_tableize%_endpoint_spec.rb.tt
+++ b/lib/gris/generators/templates/api/spec/endpoints/%name_tableize%_endpoint_spec.rb.tt
@@ -40,26 +40,28 @@ describe <%= name.classify.pluralize %>Endpoint do
     end
     let(:<%= name.underscore %>1) { Fabricate(:<%= name.underscore %>, attributes: <%= name.underscore %>_details) }
 
-    it 'creates a <%= name.underscore %>' do
+    it 'creates <%= name.underscore.with_indefinite_article %>' do
       <%= name.underscore %> = client.<%= name.tableize %>._post(<%= name.underscore %>: <%= name.underscore %>_details)
       expect(<%= name.underscore %>.replace_me).to eq <%= name.underscore %>_details[:replace_me]
     end
 
-    it 'returns a <%= name.underscore %>' do
+    it 'returns <%= name.underscore.with_indefinite_article %>' do
       <%= name.underscore %> = client.<%= name.underscore %>(id: <%= name.underscore %>1.id)
       expect(<%= name.underscore %>.id).to eq <%= name.underscore %>1.id
       expect(<%= name.underscore %>.replace_me).to eq <%= name.underscore %>_details[:replace_me]
     end
 
-    it 'updates a <%= name.underscore %>' do
+    it 'updates <%= name.underscore.with_indefinite_article %>' do
       <%= name.underscore %> = client.<%= name.underscore %>(id: <%= name.underscore %>1.id)._patch(<%= name.underscore %>: { replace_me: 'braque is a talented artist' })
       expect(<%= name.underscore %>.id).to eq <%= name.underscore %>1.id
       expect(<%= name.underscore %>.replace_me).to eq 'braque is a talented artist'
     end
 
-    it 'deletes a <%= name.underscore %>' do
-      <%= name.underscore %> = client.<%= name.underscore %>(id: <%= name.underscore %>1.id)._delete
-      expect(<%= name.underscore %>.id).to eq <%= name.underscore %>1.id
+    it 'deletes <%= name.underscore.with_indefinite_article %>' do
+      <%= name.underscore %> = Fabricate(:<%= name.underscore %>, attributes: <%= name.underscore %>_details)
+      expect do
+        client.<%= name.underscore %>(id: <%= name.underscore %>.id)._delete
+      end.to change { <%= name.classify %>.count }.by(-1)
     end
   end
 end

--- a/lib/gris/generators/templates/scaffold/README.md.tt
+++ b/lib/gris/generators/templates/scaffold/README.md.tt
@@ -14,16 +14,12 @@ Set-Up for Development
 cd your-fork-directory
 bundle
 ```
-- `DATABASE_NAME` and `PERMITTED_TOKENS` are required environment variables. Prior to executing rake tasks, running the gris console or booting the application, set up your environment by doing **one** of the following:
-  * Use [Dotenv](https://github.com/bkeepers/dotenv)—copy `.env.example` to `.env` and `.env.test` and modify it where appropriate
-  * Export the minimum required environment variables `DATABASE_NAME` and `PERMITTED_TOKENS`
 - Set up the database
 ```
-DATABASE_NAME= PERMITTED_TOKENS= bundle exec rake db:create
-DATABASE_NAME= PERMITTED_TOKENS= bundle exec rake db:migrate
+RACK_ENV=test bundle exec rake db:create
+RACK_ENV=test bundle exec rake db:migrate
 ```
 - Verify that [Rubocop](https://github.com/bbatsov/rubocop) and specs pass.
 ```
-DATABASE_NAME= PERMITTED_TOKENS= bundle exec rake
+bundle exec rake
 ```
-

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.3.4'
+  VERSION = '0.3.5'
 
   class Version
     class << self

--- a/spec/generators/api_generator_spec.rb
+++ b/spec/generators/api_generator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Gris::Generators::ApiGenerator do
   include_context 'with generator'
-  let(:api_name) { 'foo' }
+  let(:api_name) { 'article' }
 
   before do
     endpoints_directory_path = "#{generator_tmp_directory}/app/endpoints"
@@ -16,78 +16,79 @@ describe Gris::Generators::ApiGenerator do
 
   describe 'app' do
     it 'creates an endpoint class' do
-      expected_api_file = File.join(generator_tmp_directory, 'app/endpoints/foos_endpoint.rb')
+      expected_api_file = File.join(generator_tmp_directory, 'app/endpoints/articles_endpoint.rb')
       api_code = File.read(expected_api_file)
-      expect(api_code).to match(/class FoosEndpoint/)
+      expect(api_code).to match(/class ArticlesEndpoint/)
     end
 
     it 'creates a model class' do
-      expected_model_file = File.join(generator_tmp_directory, 'app/models/foo.rb')
+      expected_model_file = File.join(generator_tmp_directory, 'app/models/article.rb')
       model_code = File.read(expected_model_file)
-      expect(model_code).to match(/class Foo/)
+      expect(model_code).to match(/class Article/)
     end
 
     it 'creates an item presenter module' do
-      expected_presenter_file = File.join(generator_tmp_directory, 'app/presenters/foo_presenter.rb')
+      expected_presenter_file = File.join(generator_tmp_directory, 'app/presenters/article_presenter.rb')
       presenter_code = File.read(expected_presenter_file)
-      expect(presenter_code).to match(/module FooPresenter/)
+      expect(presenter_code).to match(/module ArticlePresenter/)
     end
 
     it 'item presenter includes Gris::Presenter' do
-      presenter_file = File.join(generator_tmp_directory, 'app/presenters/foo_presenter.rb')
+      presenter_file = File.join(generator_tmp_directory, 'app/presenters/article_presenter.rb')
       require "./#{presenter_file}"
-      expect(FooPresenter).to include(Gris::Presenter)
+      expect(ArticlePresenter).to include(Gris::Presenter)
     end
 
     it 'creates a collection presenter module' do
-      expected_presenter_file = File.join(generator_tmp_directory, 'app/presenters/foos_presenter.rb')
+      expected_presenter_file = File.join(generator_tmp_directory, 'app/presenters/articles_presenter.rb')
       presenter_code = File.read(expected_presenter_file)
-      expect(presenter_code).to match(/module FoosPresenter/)
+      expect(presenter_code).to match(/module ArticlesPresenter/)
     end
 
     it 'collection presenter includes Gris::Presenter' do
-      presenter_file = File.join(generator_tmp_directory, 'app/presenters/foos_presenter.rb')
+      presenter_file = File.join(generator_tmp_directory, 'app/presenters/articles_presenter.rb')
       require "./#{presenter_file}"
-      expect(FoosPresenter).to include(Gris::Presenter)
+      expect(ArticlesPresenter).to include(Gris::Presenter)
     end
 
     it 'collection presenter includes Gris::PaginatedPresenter' do
-      presenter_file = File.join(generator_tmp_directory, 'app/presenters/foos_presenter.rb')
+      presenter_file = File.join(generator_tmp_directory, 'app/presenters/articles_presenter.rb')
       require "./#{presenter_file}"
-      expect(FoosPresenter).to include(Gris::PaginatedPresenter)
+      expect(ArticlesPresenter).to include(Gris::PaginatedPresenter)
     end
 
     it 'mounts new endpoint in ApplicationEndpoint' do
       expected_endpoint_file = File.join(generator_tmp_directory, 'app/endpoints/application_endpoint.rb')
       endpoint_file = File.read(expected_endpoint_file)
-      expect(endpoint_file).to match(/mount FoosEndpoint/)
+      expect(endpoint_file).to match(/mount ArticlesEndpoint/)
     end
 
     it 'adds links to RootPresenter' do
       expected_root_presenter_file = File.join(generator_tmp_directory, 'app/presenters/root_presenter.rb')
       presenter_file = File.read(expected_root_presenter_file)
-      expect(presenter_file).to match(/link :foo do |opts|/)
-      expect(presenter_file).to match(/link :foos do |opts|/)
+      expect(presenter_file).to match(/link :article do |opts|/)
+      expect(presenter_file).to match(/link :articles do |opts|/)
     end
   end
 
   describe 'spec' do
     it 'creates an api spec' do
-      expected_api_file = File.join(generator_tmp_directory, 'spec/endpoints/foos_endpoint_spec.rb')
+      expected_api_file = File.join(generator_tmp_directory, 'spec/endpoints/articles_endpoint_spec.rb')
       api_code = File.read(expected_api_file)
-      expect(api_code).to match(/describe FoosEndpoint/)
+      expect(api_code).to match(/describe ArticlesEndpoint/)
+      expect(api_code).to match(/returns an article/)
     end
 
     it 'creates a fabricator' do
-      expected_fabricator_file = File.join(generator_tmp_directory, 'spec/fabricators/foos_fabricator.rb')
+      expected_fabricator_file = File.join(generator_tmp_directory, 'spec/fabricators/articles_fabricator.rb')
       fabricator_code = File.read(expected_fabricator_file)
-      expect(fabricator_code).to include 'Fabricator(:foo) do'
+      expect(fabricator_code).to include 'Fabricator(:article) do'
     end
 
     it 'creates a model spec' do
-      expected_model_file = File.join(generator_tmp_directory, 'spec/models/foo_spec.rb')
+      expected_model_file = File.join(generator_tmp_directory, 'spec/models/article_spec.rb')
       model_code = File.read(expected_model_file)
-      expect(model_code).to match(/describe Foo/)
+      expect(model_code).to match(/describe Article/)
     end
   end
 end


### PR DESCRIPTION
* corrects the setup instructions in the Readme files for generated Gris apps
* updates the delete specs for generated apis to verify that the count of records has changed
* we could just update the spec text to not assume an indefinite article but short of that, this adds https://github.com/rossmeissl/indefinite_article to generate the correct form.