### PR TITLE
@starsirius: version bump; adds GrisPaginator to newly scaffolded gris apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gris (0.4.0)
+    gris (0.4.1)
       activesupport (~> 4.2, >= 4.2.0)
       chronic (~> 0.10.0)
       dalli (~> 2.7)
@@ -74,7 +74,7 @@ GEM
     ffi (1.9.8)
     futuroscope (0.1.11)
     git (1.2.9.1)
-    grape (0.12.0)
+    grape (0.13.0)
       activesupport
       builder
       hashie (>= 2.1.0)
@@ -84,7 +84,7 @@ GEM
       rack-accept
       rack-mount
       virtus (>= 1.0.0)
-    grape-entity (0.4.7)
+    grape-entity (0.4.8)
       activesupport
       multi_json (>= 1.3.2)
     grape-roar (0.3.0)

--- a/lib/gris/generators/templates/api/app/endpoints/%name_tableize%_endpoint.rb.tt
+++ b/lib/gris/generators/templates/api/app/endpoints/%name_tableize%_endpoint.rb.tt
@@ -7,8 +7,7 @@ class <%= name.classify.pluralize %>Endpoint < Grape::API
     end
     get do
       conditions = {}
-      <%= name.underscore.tableize %> = <%= name.classify %>.where(conditions)
-      present Kaminari.paginate_array(<%= name.underscore.tableize %>).page(params[:page]).per(params[:size]), with: <%= name.classify.pluralize %>Presenter
+      paginate <%= name.classify %>, conditions: conditions, with: <%= name.classify.pluralize %>Presenter
     end
 
     desc 'Create new <%= name.underscore %>.'

--- a/lib/gris/generators/templates/scaffold/Gemfile.tt
+++ b/lib/gris/generators/templates/scaffold/Gemfile.tt
@@ -7,6 +7,7 @@ gem 'activerecord', '~> 4.2.0', require: 'active_record'
 gem 'json'
 
 gem 'gris'
+gem 'gris_paginator'
 
 gem 'roar'
 gem 'grape-roar', '~> 0.3.0'

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 
   class Version
     class << self

--- a/spec/generators/api_generator_spec.rb
+++ b/spec/generators/api_generator_spec.rb
@@ -21,6 +21,12 @@ describe Gris::Generators::ApiGenerator do
       expect(api_code).to match(/class ArticlesEndpoint/)
     end
 
+    it 'endpoint class uses GrisPaginator' do
+      expected_api_file = File.join(generator_tmp_directory, 'app/endpoints/articles_endpoint.rb')
+      api_code = File.read(expected_api_file)
+      expect(api_code).to match(/paginate Article, conditions: conditions, with: ArticlesPresenter/)
+    end
+
     it 'creates a model class' do
       expected_model_file = File.join(generator_tmp_directory, 'app/models/article.rb')
       model_code = File.read(expected_model_file)

--- a/spec/generators/scaffold_generator_spec.rb
+++ b/spec/generators/scaffold_generator_spec.rb
@@ -54,6 +54,11 @@ describe Gris::Generators::ScaffoldGenerator do
       expect(gemfile).to match(/gem 'puma'/)
     end
 
+    it 'adds the gris_paginator gem in the Gemfile' do
+      gemfile = File.read("#{app_path}/Gemfile")
+      expect(gemfile).to match(/gem 'gris_paginator'/)
+    end
+
     it 'generates an application endpoint' do
       expect(File).to exist("#{app_path}/app/endpoints/application_endpoint.rb")
     end


### PR DESCRIPTION
I extracted the default pagination we were doing into [GrisPaginator](https://github.com/dylanfareed/gris-paginator). This also provides straightforward paths to sorting.

After this PR, newly generated api endpoints will use GrisPaginator's paginate helper by default.

Existing Gris apps will need to have the gris_paginator gem added to their Gemfiles.
