### PR TITLE
@mzikherman: Automatically add directories in /app to ActiveSupport::Dependencies.autoload_paths; version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gris (0.5.0)
+    gris (0.5.1)
       activesupport (~> 4.2, >= 4.2.0)
       chronic (~> 0.10.0)
       dalli (~> 2.7)
@@ -164,7 +164,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uber (0.0.14)
+    uber (0.0.15)
     uri_template (0.7.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -187,6 +187,3 @@ DEPENDENCIES
   hyperclient
   rspec (~> 3.3)
   rubocop
-
-BUNDLED WITH
-   1.10.6

--- a/lib/gris/generators/templates/scaffold/config/application.rb.tt
+++ b/lib/gris/generators/templates/scaffold/config/application.rb.tt
@@ -3,8 +3,8 @@ require File.expand_path('../boot', __FILE__)
 # autoload initalizers
 Dir['./config/initializers/**/*.rb'].map { |file| require file }
 
-# autoload app
-relative_load_paths = %w(app/endpoints app/presenters app/models)
+# Autoload directories within /app
+relative_load_paths = Dir.glob 'app/**/*/'
 ActiveSupport::Dependencies.autoload_paths += relative_load_paths
 
 module <%= app_name.classify %>

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 
   class Version
     class << self

--- a/spec/generators/scaffold_generator_spec.rb
+++ b/spec/generators/scaffold_generator_spec.rb
@@ -59,6 +59,21 @@ describe Gris::Generators::ScaffoldGenerator do
       expect(gemfile).to match(/gem 'gris_paginator'/)
     end
 
+    it 'generates a config/application.rb file' do
+      expect(File).to exist("#{app_path}/config/application.rb")
+    end
+
+    context 'config/application.rb' do
+      let(:config_application_file) { File.read("#{app_path}/config/application.rb") }
+
+      it 'adds directories in /app to ActiveSupport::Dependencies.autoload_paths' do
+        expect(config_application_file).to include "relative_load_paths = Dir.glob 'app/**/*/'"
+        expect(config_application_file).to include(
+          'ActiveSupport::Dependencies.autoload_paths += relative_load_paths'
+        )
+      end
+    end
+
     it 'generates an application endpoint' do
       expect(File).to exist("#{app_path}/app/endpoints/application_endpoint.rb")
     end


### PR DESCRIPTION
Feels like a saner default than manually listing the subdirectories a la:
`relative_load_paths = %w(app/endpoints app/models app/presenters app/reports app/services)`