### PR TITLE
@mzikherman: enable grape cascade by default for newly scaffold Gris apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gris (0.5.3)
+    gris (0.5.4)
       activesupport (~> 4.2, >= 4.2.0)
       chronic (~> 0.10.0)
       dalli (~> 2.7)
@@ -187,3 +187,6 @@ DEPENDENCIES
   hyperclient
   rspec (~> 3.3)
   rubocop
+
+BUNDLED WITH
+   1.10.6

--- a/lib/gris/generators/templates/scaffold/app/endpoints/application_endpoint.rb
+++ b/lib/gris/generators/templates/scaffold/app/endpoints/application_endpoint.rb
@@ -2,6 +2,7 @@ class ApplicationEndpoint < Grape::API
   format :json
   formatter :json, Grape::Formatter::Roar
   content_type :json, 'application/hal+json'
+  cascade true
 
   desc 'Get the Root API Endpoint'
   get do

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 
   class Version
     class << self

--- a/spec/generators/scaffold_generator_spec.rb
+++ b/spec/generators/scaffold_generator_spec.rb
@@ -93,6 +93,10 @@ describe Gris::Generators::ScaffoldGenerator do
         expect(application_api_file).to include "content_type :json, 'application/hal+json'"
       end
 
+      it 'the application endpoint enables cascading' do
+        expect(application_api_file).to include 'cascade true'
+      end
+
       it 'mounts the RootPresenter' do
         expect(application_api_file).to match(/present self, with: RootPresenter/)
       end

--- a/spec/integration/application_accept_content_types_spec.rb
+++ b/spec/integration/application_accept_content_types_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'faraday'
+
+describe 'cascade api versions' do
+  include_context 'with a generated app'
+
+  it 'returns a the default content_type' do
+    request = Faraday.get "http://localhost:#{app_port}/", {}, 'Accept' => 'vnd.bogus-v2+json'
+    expect(request.to_hash[:response_headers]['content-type']).to eq(
+      'application/hal+json'
+    )
+    expect(request.status).to eq 200
+  end
+end

--- a/spec/integration/application_error_response_spec.rb
+++ b/spec/integration/application_error_response_spec.rb
@@ -8,7 +8,7 @@ describe 'application error response' do
     request = Faraday.get "http://localhost:#{app_port}/bogus"
     response = JSON.parse request.body
     expect(request.status).to eq 404
-    expect(response['status']).to eq 404
+    expect(response['code']).to eq 404
     expect(response['message']).to eq ['Not Found']
   end
 end


### PR DESCRIPTION
Currently, by default, if you make a request to a Gris API with an unsupported accept header, you will get a 404 error. This is a Grape behavior described here: https://github.com/ruby-grape/grape#header.

This change simply enables the cascade to a valid content_type for new Gris APIs.