### PR TITLE
version bump; reverts grape update from 0.16.1 to 0.15.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    gris (0.6.4)
+    gris (0.6.5)
       activesupport (~> 4.2, >= 4.2.0)
       chronic (~> 0.10.0)
       dalli (~> 2.7)
       git (~> 1.2, >= 1.2.8)
-      grape (>= 0.11.0)
+      grape (>= 0.11.0, < 0.16)
       grape-roar (~> 0.3.0, >= 0.3.0)
       grape-swagger (~> 0.10.0)
       hashie-forbidden_attributes (~> 0.1.0)
@@ -54,7 +54,6 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    enumerable-lazy (0.0.1)
     equalizer (0.0.11)
     fakefs (0.8.1)
     faraday (0.9.2)
@@ -72,15 +71,15 @@ GEM
     ffi (1.9.10)
     futuroscope (0.1.11)
     git (1.3.0)
-    grape (0.16.1)
+    grape (0.15.0)
       activesupport
       builder
       hashie (>= 2.1.0)
       multi_json (>= 1.3.2)
       multi_xml (>= 0.5.2)
-      mustermann19 (~> 0.4.3)
       rack (>= 1.3.0)
       rack-accept
+      rack-mount
       virtus (>= 1.0.0)
     grape-entity (0.4.8)
       activesupport
@@ -115,8 +114,6 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mustermann19 (0.4.3)
-      enumerable-lazy
     net-http-digest_auth (1.4)
     parser (2.3.0.7)
       ast (~> 2.2)
@@ -124,6 +121,8 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
+    rack-mount (0.8.3)
+      rack (>= 1.0.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     racksh (1.0.0)

--- a/gris.gemspec
+++ b/gris.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'git', '~> 1.2', '>= 1.2.8'
   s.add_runtime_dependency 'logging', '~> 2.0'
-  s.add_runtime_dependency 'grape', '>= 0.11.0'
+  s.add_runtime_dependency 'grape', '>= 0.11.0', '< 0.16'
   s.add_runtime_dependency 'grape-roar', '~> 0.3.0', '>= 0.3.0'
   s.add_runtime_dependency 'grape-swagger', '~> 0.10.0'
   s.add_runtime_dependency 'roar', '~> 1.0.1'

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.6.4'.freeze
+  VERSION = '0.6.5'.freeze
 
   class Version
     class << self

--- a/spec/integration/application_error_response_spec.rb
+++ b/spec/integration/application_error_response_spec.rb
@@ -9,6 +9,6 @@ describe 'application error response' do
     response = JSON.parse request.body
     expect(request.status).to eq 404
     expect(response['status']).to eq 404
-    expect(response['message']).to eq ['404 Not Found']
+    expect(response['message']).to eq ['Not Found']
   end
 end

--- a/spec/middleware/error_handlers_spec.rb
+++ b/spec/middleware/error_handlers_spec.rb
@@ -49,7 +49,7 @@ describe Gris::Middleware::ErrorHandlers do
     it 'retuns a Not Found error for missing routes' do
       get '/bogus'
       expect(response_code).to eq 404
-      expect(response_body).to eq '404 Not Found'
+      expect(response_body).to eq 'Not Found'
     end
 
     it 'returns a formatted message for gris_error!' do


### PR DESCRIPTION
Relating to - https://github.com/ruby-grape/grape/issues/1348 & https://bugs.ruby-lang.org/issues/12251

Updating Grape to 0.16.1 will tank the spec suites that use the fabricator gem (which Gris includes by default in new apps) because of global namespace collisions. We'll keep an eye on that Grape issue and relax this as we are able.